### PR TITLE
Update scripts to use fallback API key

### DIFF
--- a/src/performance_analytics.py
+++ b/src/performance_analytics.py
@@ -12,7 +12,7 @@ from src.talent_identification import fetch_epl_player_data # To get player list
 
 # Load API key from .env file
 load_dotenv()
-api_key = os.getenv("BALLDONTLIE_API_KEY")
+api_key = os.getenv("BALLDONTLIE_API_KEY", "44212920-29e5-46e6-a4dc-945d70701669")
 
 # Initialize client (though we'll mostly simulate detailed event data)
 # client = SportsClient(api_key=api_key) # Uncomment if real API calls for events are made
@@ -151,11 +151,8 @@ def calculate_progressive_pass_metrics(player_df, pass_events_df):
     return player_df
 
 if __name__ == "__main__":
-    if not api_key:
-        print("BALLDONTLIE_API_KEY not found. Please set it in a .env file or as an environment variable.")
-    else:
-        print("Fetching base player data (names, minutes played)...")
-        # We use fetch_epl_player_data to get a list of players and their minutes played.
+    print("Fetching base player data (names, minutes played)...")
+    # We use fetch_epl_player_data to get a list of players and their minutes played.
         # This function from Challenge 1 already fetches season stats including 'minutes_played'.
         # In a real scenario, you might fetch this differently if not doing Challenge 1 first.
         base_player_data_df = fetch_epl_player_data(season=2023) # Fetches bio and aggregated stats

--- a/src/talent_identification.py
+++ b/src/talent_identification.py
@@ -12,7 +12,7 @@ from src.client import SportsClient
 
 # Load API key from .env file
 load_dotenv()
-api_key = os.getenv("BALLDONTLIE_API_KEY")
+api_key = os.getenv("BALLDONTLIE_API_KEY", "44212920-29e5-46e6-a4dc-945d70701669")
 
 # Initialize client
 client = SportsClient(api_key=api_key)
@@ -145,20 +145,10 @@ if __name__ == "__main__":
     # This requires the BALLDONTLIE_API_KEY to be set in a .env file or environment
     # Create a .env file in the root with: BALLDONTLIE_API_KEY="your_api_key_here"
 
-    # Check if API key is available
-    if not api_key:
-        print("BALLDONTLIE_API_KEY not found. Please set it in a .env file or as an environment variable.")
-        print("Example .env file content: BALLDONTLIE_API_KEY=\"your_actual_api_key\"")
-        # Create a dummy .env if it doesn't exist to guide the user
-        if not os.path.exists(".env"):
-            with open(".env", "w") as f:
-                f.write("BALLDONTLIE_API_KEY=\"your_api_key_here\"\n")
-            print("Created a template .env file. Please fill in your API key.")
-    else:
-        print("Fetching and processing player data...")
-        player_data_df = fetch_epl_player_data(season=2023) # Using 2023 as an example season
+    print("Fetching and processing player data...")
+    player_data_df = fetch_epl_player_data(season=2023) # Using 2023 as an example season
 
-        if not player_data_df.empty:
+    if not player_data_df.empty:
             print("\nRaw data sample:")
             print(player_data_df.head())
 

--- a/src/transfer_optimization.py
+++ b/src/transfer_optimization.py
@@ -14,8 +14,8 @@ from src.performance_analytics import calculate_progressive_pass_metrics, simula
 
 # Load API key
 load_dotenv()
-api_key = os.getenv("BALLDONTLIE_API_KEY")
-client = SportsClient(api_key=api_key) if api_key else None
+api_key = os.getenv("BALLDONTLIE_API_KEY", "44212920-29e5-46e6-a4dc-945d70701669")
+client = SportsClient(api_key=api_key)
 
 def get_team_standings(season=2023):
     """Fetches league standings."""
@@ -151,11 +151,8 @@ def recommend_players(target_team_name, position_needed, all_players_df, max_age
 
 
 if __name__ == "__main__":
-    if not client:
-        print("BALLDONTLIE_API_KEY not found or client not initialized. Transfer optimization script cannot run fully.")
-    else:
-        print("Starting Transfer Strategy Optimization process...")
-        current_season = 2023 # Example season
+    print("Starting Transfer Strategy Optimization process...")
+    current_season = 2023 # Example season
 
         # 1. Fetch all necessary data
         print("\nFetching team standings...")


### PR DESCRIPTION
Modified talent_identification.py, performance_analytics.py, and transfer_optimization.py to use a default public API key if the BALLDONTLIE_API_KEY environment variable is not set. This mirrors the behavior in the quickstart notebook.